### PR TITLE
feat: code signing

### DIFF
--- a/.github/tools/add-macos-cert.sh
+++ b/.github/tools/add-macos-cert.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+KEY_CHAIN=build.keychain
+MACOS_CERT_P12_FILE=certificate.p12
+
+# Recreate the certificate from the secure environment variable
+echo $MACOS_CERT_P12 | base64 --decode > $MACOS_CERT_P12_FILE
+
+#create a keychain
+security create-keychain -p actions $KEY_CHAIN
+
+# Make the keychain the default so identities are found
+security default-keychain -s $KEY_CHAIN
+
+# Unlock the keychain
+security unlock-keychain -p actions $KEY_CHAIN
+
+security import $MACOS_CERT_P12_FILE -k $KEY_CHAIN -P $MACOS_CERT_PASSWORD -T /usr/bin/codesign;
+
+security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
+
+# remove certs
+rm -fr *.p12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,22 @@ jobs:
       - name: Install dependencies
         run: npm ci && cd ./installer && npm ci
 
+      - name: Set MacOS signing certs
+        if: matrix.os == 'macos-latest'
+        run: .github/tools/add-macos-cert.sh
+        env:
+          MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+
+      - name: Set Windows signing certificate
+        if: matrix.os == 'windows-latest'
+        continue-on-error: true
+        id: write_file
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'win-certificate.pfx'
+          encodedString: ${{ secrets.WINDOWS_CODESIGN_P12 }}
+
       - name: Configure secrets
         uses: jossef/action-set-json-field@v1
         with:
@@ -30,7 +46,11 @@ jobs:
 
       - name: Publish
         env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WINDOWS_CODESIGN_FILE: ${{ steps.write_file.outputs.filePath }}
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
         run: npm run publish
 
       - name: Create Sentry release

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,6 +1,16 @@
 const path = require('path')
+const fs = require('fs')
 
 // Taken over from https://github.com/electron/fiddle/blob/main/forge.config.js
+
+if (process.env['WINDOWS_CODESIGN_FILE']) {
+  const certPath = path.join(__dirname, 'win-certificate.pfx')
+  const certExists = fs.existsSync(certPath)
+
+  if (certExists) {
+    process.env['WINDOWS_CODESIGN_FILE'] = certPath
+  }
+}
 
 const iconPath = path.resolve(__dirname, 'assets', 'icon.icns')
 
@@ -15,10 +25,12 @@ const config = {
       OriginalFilename: 'Swarm Desktop',
     },
     osxSign: {
+      identity: '3rd Party Mac Developer Application: Swarm Association (9J9SPHU9RP)',
       hardenedRuntime: true,
       'gatekeeper-assess': false,
       entitlements: 'assets/entitlements.plist',
       'entitlements-inherit': 'assets/entitlements.plist',
+      'signature-flags': 'library',
     },
   },
   electronInstallerDebian: {
@@ -29,6 +41,8 @@ const config = {
       name: '@electron-forge/maker-squirrel',
       config: {
         name: 'swarm-desktop',
+        certificateFile: process.env['WINDOWS_CODESIGN_FILE'],
+        certificatePassword: process.env['WINDOWS_CODESIGN_PASSWORD'],
       },
     },
     {
@@ -61,5 +75,30 @@ const config = {
     },
   ],
 }
+
+function notarizeMaybe() {
+  if (process.platform !== 'darwin') {
+    return
+  }
+
+  if (!process.env.CI) {
+    console.log(`Not in CI, skipping notarization`)
+    return
+  }
+
+  if (!process.env.APPLE_ID || !process.env.APPLE_ID_PASSWORD) {
+    console.warn('Should be notarizing, but environment variables APPLE_ID or APPLE_ID_PASSWORD are missing!')
+    return
+  }
+
+  config.packagerConfig.osxNotarize = {
+    appBundleId: 'org.ethswarm.swarmDesktop',
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_ID_PASSWORD,
+    ascProvider: '9J9SPHU9RP',
+  }
+}
+
+notarizeMaybe()
 
 module.exports = config


### PR DESCRIPTION
This adds support for Code Signing for macOS and Windows. We need to setup though following secrets:
 - `MACOS_CERT_P12` - macOS signing certificate
 - `MACOS_CERT_PASSWORD` - password for the macOS certificate
 - `WINDOWS_CODESIGN_P12` -  Windows signing certificate
 - `WINDOWS_CODESIGN_PASSWORD` -  password for the Windows certificate

Moreover the [Apple Developer Identity](https://github.com/ethersphere/bee-desktop/pull/137/files#diff-0afe94b5ad1971b035d2d538a77509ebe4f7ecd7a16313e3ac63025dfd865f8bR26)

Closes #3 