### PR TITLE
build: zip darwin distribution for auto updates

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -59,6 +59,11 @@ const config = {
       name: '@electron-forge/maker-rpm',
       config: {},
     },
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin'],
+      config: {},
+    },
   ],
   publishers: [
     {


### PR DESCRIPTION
As per documentation https://github.com/electron/update-electron-app#what-kinds-of-assets-do-i-need-to-build we need to have ZIPed distro for Macos's auto updates