### PR TITLE
fix: remove unused properties from first time created config.yaml (#439)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -26,8 +26,6 @@ function getBeeExecutable() {
 
 function createConfiguration() {
   return `api-addr: 127.0.0.1:1633
-debug-api-addr: 127.0.0.1:1635
-debug-api-enable: true
 swap-enable: false
 mainnet: true
 full-node: false


### PR DESCRIPTION
During first time installation, the created `config.yaml` is correct without unused properties.