### PR TITLE
fix: screenshot plugin encrypted link

### DIFF
--- a/src/plugins/screenshot/windows/preview/preview.css
+++ b/src/plugins/screenshot/windows/preview/preview.css
@@ -117,6 +117,10 @@ label {
     color: #666;
 }
 
+.modal-main p.danger {
+    color: red;
+}
+
 .modal-main .check-cnx {
     margin-top: 124px;
 }

--- a/src/plugins/screenshot/windows/preview/preview.html
+++ b/src/plugins/screenshot/windows/preview/preview.html
@@ -504,7 +504,7 @@
      */
         function displayResultRefCid(res, modalContent) {
             const LOCAL_ENDPOINT = 'http://localhost:1633/bzz'
-            const GATEWAY_ENDPOINT = 'https://gateway.ethswarm.org/access'
+            const GATEWAY_ENDPOINT = 'https://bzz.link/bzz'
 
             res = JSON.parse(res);
 

--- a/src/plugins/screenshot/windows/preview/preview.html
+++ b/src/plugins/screenshot/windows/preview/preview.html
@@ -513,7 +513,9 @@
                 classes: ["ref-cid"],
             });
 
-            uploadResultDiv.innerHTML = `
+            if (res.reference.length < 128) {
+                // Not encrypted
+                uploadResultDiv.innerHTML = `
                     <div>
                         <h2>File published successfully.</h2>
                         <p>Use the links below to access it.</p>
@@ -522,22 +524,44 @@
                         <li>
                             ${LOCAL_ENDPOINT}/${trimRef(res.reference)}
                                 <span class='tooltip'>
-                                <span class='tooltip-hash'>${LOCAL_ENDPOINT}/${res.reference
-                }/</span>
+                                <span class='tooltip-hash'>${LOCAL_ENDPOINT}/${res.reference}/</span>
                                 <span class='copy-icon'></span>
                                 <span class='tooltip-text'>Copy</span>
                             </span>
                         </li>
                         <li>
-                        ${GATEWAY_ENDPOINT}/${trimRef(res.reference)}
+                            ${GATEWAY_ENDPOINT}/${trimRef(res.reference)}
                             <span class='tooltip'>
-                                <span class='tooltip-hash'>${GATEWAY_ENDPOINT}/${res.reference
-                }/</span>
+                                <span class='tooltip-hash'>${GATEWAY_ENDPOINT}/${res.reference}/</span>
                                 <span class='copy-icon'></span>
                                 <span class='tooltip-text'>Copy</span>
                             </span>
                         </li>
                     </ul>`;
+            } else {
+                // Encrypted
+                uploadResultDiv.innerHTML = `
+                    <div>
+                        <h2>File published successfully.</h2>
+                        <p>Use the link below to access it.</p>
+                        <p class='danger'>
+                            🔥 DANGER
+                            <br />Never use public gateways when requesting full encrypted references.
+                            <br />The hash contains sensitive key information which should be kept private.
+                            <br />Run your own node to use Bee's encryption features.
+                        </p>
+                    </div>
+                    <ul>
+                        <li>
+                            ${LOCAL_ENDPOINT}/${trimRef(res.reference)}
+                            <span class='tooltip'>
+                                <span class='tooltip-hash'>${LOCAL_ENDPOINT}/${res.reference}/</span>
+                                <span class='copy-icon'></span>
+                                <span class='tooltip-text'>Copy</span>
+                            </span>
+                        </li>
+                    </ul>`;
+            }
 
             modalContent.firstElementChild.firstElementChild.innerHTML = "";
             modalContent.firstElementChild.firstElementChild.append(uploadResultDiv);


### PR DESCRIPTION
Replace gateway link with `bzz.link/bzz`. When the upload is encrypted, show only the localhost link and display info message explaining how to handle encrypted hashes.